### PR TITLE
Fix dataset path for Windows Store notebooks

### DIFF
--- a/Windows_Store_Apps.ipynb
+++ b/Windows_Store_Apps.ipynb
@@ -39,7 +39,7 @@
       "source": [
         "import pandas as pd\n",
         "\n",
-        "df = pd.read_csv('/content/drive/My Drive/Colab Notebooks/data/msft.csv', index_col = 'Date')\n",
+        "df = pd.read_csv('data/msft.csv', index_col = 'Date')\n",
         "df.head()"
       ],
       "execution_count": 20,

--- a/Windows_Store_Apps/Windows_Store_Apps.ipynb
+++ b/Windows_Store_Apps/Windows_Store_Apps.ipynb
@@ -39,7 +39,7 @@
       "source": [
         "import pandas as pd\n",
         "\n",
-        "df = pd.read_csv('/content/drive/My Drive/Colab Notebooks/data/msft.csv', index_col = 'Date')\n",
+        "df = pd.read_csv('data/msft.csv', index_col = 'Date')\n",
         "df.head()"
       ],
       "execution_count": 20,

--- a/windows_store_apps/Windows_Store_Apps.ipynb
+++ b/windows_store_apps/Windows_Store_Apps.ipynb
@@ -39,7 +39,7 @@
       "source": [
         "import pandas as pd\n",
         "\n",
-        "df = pd.read_csv('/content/drive/My Drive/Colab Notebooks/data/msft.csv', index_col = 'Date')\n",
+        "df = pd.read_csv('data/msft.csv', index_col = 'Date')\n",
         "df.head()"
       ],
       "execution_count": 20,


### PR DESCRIPTION
## Summary
- update Windows Store analysis notebooks to load `data/msft.csv` locally

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68693c68dc5c83308355922d8504d5af