### PR TITLE
Add pytest for msft.csv and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # ds-showncase
 A showcase of all Jimmy's Data Science stuffs
+
+## Running tests
+
+This project uses `pytest` for unit testing. To execute the tests, install the dependencies and run `pytest` from the repository root:
+
+```bash
+pip install -U pandas pytest
+pytest
+```

--- a/tests/test_msft_csv.py
+++ b/tests/test_msft_csv.py
@@ -1,0 +1,10 @@
+import os
+import pandas as pd
+
+
+def test_msft_csv_columns():
+    csv_path = os.path.join('windows_store_apps', 'data', 'msft.csv')
+    df = pd.read_csv(csv_path)
+    expected_cols = ['Name', 'Rating', 'No of people Rated', 'Category', 'Date', 'Price']
+    assert list(df.columns) == expected_cols
+


### PR DESCRIPTION
## Summary
- add a basic test to load `windows_store_apps/data/msft.csv`
- document how to run `pytest`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68693e2425e48330aa20f667b3367e22